### PR TITLE
Remove @override from createJSModules method in AudioPackage.java

### DIFF
--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPackage.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPackage.java
@@ -19,7 +19,6 @@ public class AudioPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Remove @override from createJSModules method in AudioPackage.java which was deprecated in RN 0.47.1